### PR TITLE
Update to use stack resolver lts-14.12

### DIFF
--- a/src/Warwick/Common.hs
+++ b/src/Warwick/Common.hs
@@ -58,7 +58,7 @@ class HasBaseUrl a where
 --------------------------------------------------------------------------------
 
 data APIError
-    = TransportError ServantError
+    = TransportError ClientError
     deriving Show
 
 -- | Represents computations involving a Warwick API.

--- a/src/Warwick/Tabula.hs
+++ b/src/Warwick/Tabula.hs
@@ -108,7 +108,7 @@ withTabula inst APIConfig{..} m = do
 
     case r of
         Left serr -> case serr of 
-            FailureResponse res -> case decode (responseBody res) of
+            FailureResponse _ res -> case decode (responseBody res) of
                 Nothing -> pure $ Left $ TransportError serr
                 Just er -> pure $ Left er
             _ -> pure $ Left $ TransportError serr

--- a/src/Warwick/Tabula/Types.hs
+++ b/src/Warwick/Tabula/Types.hs
@@ -61,7 +61,7 @@ instance ToJSON TabulaError where
 type Tabula = StateT APISession (ExceptT TabulaErr ClientM)
 
 data TabulaErr 
-    = TransportError ServantError 
+    = TransportError ClientError 
     | TabulaErrorRes {
          tabulaErrStatus   :: String,
          tabulaErrMessages :: [TabulaError]

--- a/stack.yaml
+++ b/stack.yaml
@@ -16,7 +16,7 @@
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
 #resolver: lts-9.17
-resolver: lts-13.26
+resolver: lts-14.12
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -40,7 +40,8 @@ packages:
 - .
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps:
+- feed-1.3.0.1
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,10 +3,17 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: feed-1.3.0.1@sha256:9caae597e46f178e8a3a5d52914190d4063ed1003091761fb852ea10818c7a92,3878
+    pantry-tree:
+      size: 2843
+      sha256: cf5d9c4ab1fd7e5aec6de245711a080e1d21b30bbe8901b8c6172d95fdc2a802
+  original:
+    hackage: feed-1.3.0.1
 snapshots:
 - completed:
-    size: 499889
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/13/26.yaml
-    sha256: ecb02ee16829df8d7219e7d7fe6c310819820bf335b0b9534bce84d3ea896684
-  original: lts-13.26
+    size: 545658
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/12.yaml
+    sha256: 26b807457213126d26b595439d705dc824dbb7618b0de6b900adc2bf6a059406
+  original: lts-14.12


### PR DESCRIPTION
Updates APIs from `lts-13.26` to `lts-14.12`. 

Notes:
- `ServantError` is renamed to `ClientError` in `servant-0.16`
- `FailureResponse` now has an extra parameter
- `feed-1.3.0.1` is used, as version `1.2.0.1` used by resolver includes change that means `HTMLContent` takes `XML` not `Text`. This is reverted in `1.3.0.1`